### PR TITLE
API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Brazilian's Forgery
 
-Forgery extention with a tons of Brazilian things like names, cities, and others.
-
+Forgery extension with a tons of Brazilian things like names, cities, and others.
 
 ## Using
 
@@ -14,7 +13,7 @@ Brazilian's Forgery primary uses the awesome [Forgery](https://github.com/sevenw
 * Female first names
 * Last names
 * Male first names
-* States abreviations
+* States abbreviations
 * States
 * Streets
 
@@ -25,7 +24,7 @@ Brazilian's Forgery primary uses the awesome [Forgery](https://github.com/sevenw
 * Zip
 
 
-### Full List of aditional Forgeries:
+### Full List of additional Forgeries:
 
 Method                                          | Example Output
 :------------------------------                 |:----------------
@@ -35,11 +34,11 @@ Method                                          | Example Output
 `Forgery('bank').agency_number`                 | 1234-3
 `Forgery('bank').account_number`                | 1234567-3
                                                 |
-`Forgery('cnpj').numeric`                       | 57222068000132
-`Forgery('cnpj').formatted`                     | 22.792.949/0001-04
+`Forgery('CNPJ').numeric`                       | 57222068000132
+`Forgery('CNPJ').formatted`                     | 22.792.949/0001-04
                                                 |
-`Forgery('cpf').numeric`                        | 11438374798
-`Forgery('cpf').formatted`                      | 059.893.186-42
+`Forgery('CPF').numeric`                        | 11438374798
+`Forgery('CPF').formatted`                      | 059.893.186-42
                                                 |
 `Forgery('occupation').name`                    | Engenheiro Mecânico
 
@@ -62,7 +61,7 @@ gem 'brazilian_forgery', '0.0.1'
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/brazilian_forgery/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
+2. Create your feature branch (`git checkout -b my-awesome-feature`)
+3. Commit your changes (`git commit -am 'Add the best feature'`)
+4. Push to the branch (`git push origin my-awesome-feature`)
 5. Create a new Pull Request

--- a/lib/brazilian_forgery/api.rb
+++ b/lib/brazilian_forgery/api.rb
@@ -1,4 +1,3 @@
-# Alternate Forgery api, see spec/brazilian_forgery_spec.rb for examples.
 def Forgery(forgery, method = nil, *args)
   klass = Forgery::Extend(
       "BrazilianForgery::#{Forgery::Extend(forgery.to_s).camelize}"

--- a/lib/brazilian_forgery/api.rb
+++ b/lib/brazilian_forgery/api.rb
@@ -1,5 +1,5 @@
 # Alternate Forgery api, see spec/brazilian_forgery_spec.rb for examples.
-def BrazilianForgery(forgery, method = nil, *args)
+def Forgery(forgery, method = nil, *args)
   klass = Forgery::Extend(
       "BrazilianForgery::#{Forgery::Extend(forgery.to_s).camelize}"
   ).constantize

--- a/spec/brazilian_forgery/api_spec.rb
+++ b/spec/brazilian_forgery/api_spec.rb
@@ -1,14 +1,14 @@
 describe BrazilianForgery do
   it 'returns an appropriate forgery class when a symbol is called' do
-    expect(BrazilianForgery(:bank)).to eq(BrazilianForgery::Bank)
-    expect(BrazilianForgery(:CPF)).to eq(BrazilianForgery::CPF)
-    expect(BrazilianForgery(:occupation)).to eq(BrazilianForgery::Occupation)
+    expect(Forgery(:bank)).to eq(BrazilianForgery::Bank)
+    expect(Forgery(:CPF)).to eq(BrazilianForgery::CPF)
+    expect(Forgery(:occupation)).to eq(BrazilianForgery::Occupation)
   end
 
   it 'returns an appropriate forgery class when a string is called' do
-    expect(BrazilianForgery('bank')).to eq(BrazilianForgery::Bank)
-    expect(BrazilianForgery('CPF')).to eq(BrazilianForgery::CPF)
-    expect(BrazilianForgery('occupation')).to eq(BrazilianForgery::Occupation)
+    expect(Forgery('bank')).to eq(BrazilianForgery::Bank)
+    expect(Forgery('CPF')).to eq(BrazilianForgery::CPF)
+    expect(Forgery('occupation')).to eq(BrazilianForgery::Occupation)
   end
 end
 


### PR DESCRIPTION
## Changes:
- Leave default `BrazilianForgery` name to `Forgery`.
- Corrected the specs!
- Corrected the README.md (English Errors, and updated it)
### Why "CPF and CNPJ" instead of "cpf and cnpj"??

> [Reference](https://github.com/bbatsov/ruby-style-guide#camelcase-classes). The answer is pretty simple, In ruby, is prefered to use the REAL names, instead other ones: 

Is best to call a class called XMLParser than XmlParser, and others... In real life, everyone calls XML not xml or Xml. [Please see the global reference](https://github.com/bbatsov/ruby-style-guide#camelcase-classes)
